### PR TITLE
Add base style to main components

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 @import "config/fonts";
 @import "config/colors";
 @import "config/bootstrap_variables";
+@import "config/typography";
 
 // External libraries
 @import "bootstrap-sprockets";

--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -5,7 +5,7 @@
 .alert {
   margin: 0;
   text-align: center;
-  color: white;
+  color: $white;
 }
 .alert-info {
   background: $green;

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -1,8 +1,12 @@
 .footer {
-  position: sticky;
+  position: absolute;
   bottom: 0;
-  height: 100px;
   width: 100%;
-  margin-top: 50px;
-  background: #f5f5f5;
+  padding: 2rem 4.5rem;
+  line-height: 3rem;
+  background-color: $light-gray;
+  color: $black;
+  font-weight: 300;
+  align-items: center;
+  text-align: center;
 }

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -3,6 +3,7 @@
   border-radius: 5px;
 }
 
+.form-control,
 .form-control-label,
 .form-check-label {
   font-size: $font-size-base;

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -1,0 +1,11 @@
+.form-control {
+  border: 2px solid $gray;
+  border-radius: 5px;
+}
+
+.form-control-label,
+.form-check-label {
+  font-size: $font-size-base;
+  color: $black;
+  font-weight: 400 !important;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -1,3 +1,4 @@
 // Import your components CSS files here.
 @import "alert";
 @import "navbar";
+@import "forms";

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -2,3 +2,4 @@
 @import "alert";
 @import "navbar";
 @import "forms";
+@import "footer";

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -30,6 +30,16 @@
   justify-content: space-between;
 }
 
+/* Navbar link */
+.navbar-wagon-link {
+  color: $black;
+  font-size: $font-size-base;
+}
+.navbar-wagon-link:hover {
+  color: $black-alt;
+  text-decoration: underline;
+}
+
 /* Basic navbar item */
 .navbar-wagon-item {
   cursor: pointer;
@@ -45,14 +55,14 @@
 .navbar-wagon-dropdown-menu li > a {
   transition: color 0.3s ease;
   font-weight: lighter !important;
-  color: $blue !important;
+  color: $black !important;
   font-size: $font-size-base !important;
   line-height: 1.35 !important;
   padding: 10px 20px;
 }
 .navbar-wagon-dropdown-menu li > a:hover {
   background: transparent !important;
-  color: black !important;
+  color: $black-alt !important;
 }
 .navbar-wagon-dropdown-menu:before {
   content: ' ';

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,10 +1,10 @@
 /* Main navbar */
 .navbar-wagon {
-  box-shadow: 0 1px 5px 0 rgba(0,0,0,0.07),0 1px 0 0 rgba(0,0,0,0.03);
-  background: white;
+  border-bottom: 2px solid $gray;
+  background: $white;
   transition: all 0.3s ease;
-  height: 70px;
-  padding: 0px 30px;
+  height: 80px;
+  padding: 0px 150px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -17,9 +17,10 @@
 
 /* User Avatar */
 .navbar-wagon .avatar {
-  height: 35px;
-  width: 35px;
+  height: 45px;
+  width: 45px;
   border-radius: 50%;
+  border: 2px solid $gray;
 }
 
 /* Right section */
@@ -35,28 +36,18 @@
   padding: 0 20px;
 }
 
-/* Navbar link */
-.navbar-wagon-link {
-  color: #616668;
-  font-size: 14px;
-}
-.navbar-wagon-link:hover {
-  color: #da552f;
-  text-decoration: none;
-}
-
 /* Dropdown menu */
 .navbar-wagon-dropdown-menu {
   margin-top: 15px;
-  box-shadow: 1px 1px 4px #E6E6E6;
-  border-color: #E6E6E6;
+  box-shadow: 1px 1px 4px $gray;
+  border-color: $gray;
 }
 .navbar-wagon-dropdown-menu li > a {
   transition: color 0.3s ease;
   font-weight: lighter !important;
-  color: #999999 !important;
-  font-size: 15px !important;
-  line-height: 22px !important;
+  color: $blue !important;
+  font-size: $font-size-base !important;
+  line-height: 1.35 !important;
   padding: 10px 20px;
 }
 .navbar-wagon-dropdown-menu li > a:hover {
@@ -72,6 +63,6 @@
   top: -6px;
   background-color: white;
   transform: rotate(45deg);
-  border-left: 1px solid #E6E6E6;
-  border-top: 1px solid #E6E6E6;
+  border-left: 1px solid $gray;
+  border-top: 1px solid $gray;
 }

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -3,19 +3,24 @@
 // 2. These variables are defined with default value (see https://robots.thoughtbot.com/sass-default)
 // 3. You can override them below!
 
-// General style
+// General typographic style
 $font-family-sans-serif:  $body-font;
 $headings-font-family:    $headers-font;
-$body-bg:                 $light-gray;
+$body-bg:                 $white;
 $font-size-base: 18px;
+$h1-size-base:   2.25rem;  // 40.5px
+$h2-size-base:   2rem;     // 36px
+$h3-size-base:   1.5rem;   // 27px
+$h4-size-base:   1.333rem; // 24px
+$h5-size-base:   0.667em;  // 12px
 
 // Colors
-$gray-base:       $gray;
-$brand-primary:   $blue;
-$brand-success:   $green;
-$brand-info:      $yellow;
+$gray-base:       $light-gray;
+$brand-primary:   $green;
+$brand-success:   $blue;
+$brand-info:      $orange;
 $brand-danger:    $red;
-$brand-warning:   $orange;
+$brand-warning:   $yellow;
 
 // Buttons & inputs' radius
 $border-radius-base:  2px;

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -1,10 +1,21 @@
 // Define variables for your color scheme
 
-// For example:
-$red: #EE5F5B;
-$blue: #469AE0;
-$yellow: #FDB631;
-$orange: #E67E22;
-$green: #32B796;
-$gray: #000000;
-$light-gray: #F4F4F4;
+// Default colors
+$white:  #FFFFFF;
+$red:    #ED4E37;
+$orange: #F0DA21;
+$yellow: #FDECA5;
+
+// Primary palette (main one)
+$green:      #2FBC5C;
+$light-gray: #F5F5F5;
+$gray:       #C4C4C4;
+$black:      #333333;
+$blue:       #06B5DE;
+
+// Secondary palette (darker one)
+$green-alt:      #2A9F4A;
+$light-gray-alt: #E6E6E6;
+$gray-alt:       #999999;
+$black-alt:      #242424;
+$blue-alt:       #03A1C5;

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,16 +1,6 @@
 // Import Google fonts
-@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,300,700|Raleway:400,100,300,700,500");
+@import url("https://use.typekit.net/kxh3plo.css");
 
 // Define fonts for body and headers
-$body-font: "Open Sans", "Helvetica", "sans-serif";
-$headers-font: "Raleway", "Helvetica", "sans-serif";
-
-// To use a font file (.woff) uncomment following lines
-// @font-face {
-//   font-family: "Font Name";
-//   src: font-url('FontFile.eot');
-//   src: font-url('FontFile.eot?#iefix') format('embedded-opentype'),
-//        font-url('FontFile.woff') format('woff'),
-//        font-url('FontFile.ttf') format('truetype')
-// }
-// $my-font: "Font Name";
+$body-font: "nimbus-sans", "Helvetica", "sans-serif";
+$headers-font: "nimbus-sans", "Helvetica", "sans-serif";

--- a/app/assets/stylesheets/config/_typography.scss
+++ b/app/assets/stylesheets/config/_typography.scss
@@ -1,0 +1,61 @@
+/* -------------------------------------
+ * Sizes and colors for typography
+* ------------------------------------- */
+
+// Set size for main typographic elements
+html {
+  font-size: $font-size-base !important;
+}
+
+h1 {
+  font-size: $h1-size-base;
+}
+
+h2 {
+  font-size: $h2-size-base;
+}
+
+h3 {
+  font-size: $h3-size-base;
+}
+
+h4 {
+  font-size: $h4-size-base;
+}
+
+h5 {
+  font-size: $h5-size-base;
+}
+
+p,
+a,
+li,
+body {
+  font-size: $font-size-base;
+}
+
+// Set font-weight for main typographic elements
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-weight: 700; // bold
+  line-height: 1.20; // 21,6px
+}
+
+body {
+  color: $black !important;
+  font-weight: 400; // normal
+  line-height: 1.35; // 24,3px
+}
+
+a {
+  color: $blue !important;
+  font-weight: 400; //normal
+  text-decoration: none;
+  &:hover {
+    color: $blue-alt !important;
+    text-decoration: none; // No underline on hover
+  }
+}

--- a/app/assets/stylesheets/config/_typography.scss
+++ b/app/assets/stylesheets/config/_typography.scss
@@ -51,11 +51,11 @@ body {
 }
 
 a {
-  color: $blue !important;
+  color: $blue;
   font-weight: 400; //normal
   text-decoration: none;
   &:hover {
-    color: $blue-alt !important;
+    color: $blue-alt ;
     text-decoration: none; // No underline on hover
   }
 }

--- a/app/views/housings/index.html.erb
+++ b/app/views/housings/index.html.erb
@@ -1,12 +1,9 @@
-<div class="container">
-  <h1>Ma liste de biens</h1>
-  <ul>
-   <% @housings.each do |housing| %>
-     <h2><%= housing.street %></h2>
-    <li><%= link_to housing.street, housing_path(housing) %></li>
-   <% end %>
-  </ul>
+<h1>Ma liste de biens</h1>
+<ul>
+ <% @housings.each do |housing| %>
+   <h2><%= housing.street %></h2>
+  <li><%= link_to housing.street, housing_path(housing) %></li>
+ <% end %>
+</ul>
 
-  <%= link_to "Ajouter un bien", new_housing_path, type: "button", class: "btn btn-primary" %>
-
- </div>
+<%= link_to "Ajouter un bien", new_housing_path, type: "button", class: "btn btn-primary" %>

--- a/app/views/housings/new.html.erb
+++ b/app/views/housings/new.html.erb
@@ -1,5 +1,4 @@
-<div class="container">
-  <h1>Créer un nouveau bien</h1>
+<h1>Créer un nouveau bien</h1>
 <%= simple_form_for [@housing] do |f| %>
     <%= f.input :street %>
     <%= f.input :zip_code %>
@@ -11,9 +10,4 @@
     <%= f.input :size %>
     <%= f.submit "Créer mon bien", class: "btn-yours"%>
   <% end %>
-
-  <hr>
-
-
-</div>
-
+<hr>

--- a/app/views/housings/show.html.erb
+++ b/app/views/housings/show.html.erb
@@ -1,16 +1,12 @@
+<h1>
+  <%= @housing.street %>
+</h1>
+<ul>
+  <% @rentals.each do |rental| %>
+    <li>
+      <%= rental.monthly_rent %>
+    </li>
+  <% end %>
+</ul>
 
-<div class="container">
-  <h1>
-    <%= @housing.street %>
-  </h1>
-  <ul>
-    <% @rentals.each do |rental| %>
-      <li>
-        <%= rental.monthly_rent %>
-      </li>
-    <% end %>
-  </ul>
-
-  <%= link_to "Ajouter une nouvelle location", new_housing_rental_path(@housing), type: "button", class: "btn btn-primary" %>
- </div>
-</div>
+<%= link_to "Ajouter une nouvelle location", new_housing_rental_path(@housing), type: "button", class: "btn btn-primary" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,10 +10,15 @@
     <%#= stylesheet_pack_tag 'application', media: 'all' %> <!-- Uncomment if you import CSS in app/javascript/packs/application.js -->
   </head>
   <body>
-    <%= render 'shared/navbar' %>
-    <%= render 'shared/flashes' %>
-    <%= yield %>
-    <%= javascript_include_tag 'application' %>
-    <%= javascript_pack_tag 'application' %>
+    <header
+      <%= render 'shared/navbar' %>
+      <%= render 'shared/flashes' %>
+    </header>
+    <!-- Puts everything that is not the navbar or the footer into a bootstrap container -->
+    <main class="container">
+      <%= yield %>
+      <%= javascript_include_tag 'application' %>
+      <%= javascript_pack_tag 'application' %>
+    </main>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,8 +21,10 @@
       <%= javascript_include_tag 'application' %>
       <%= javascript_pack_tag 'application' %>
     </main>
-    <footer>
-      <%= render 'shared/footer' %>
-    <footer>
+    <footer class="footer">
+      <div class="container">
+        <%= render 'shared/footer' %>
+      </div>
+    </footer>
   </body>
 </html>

--- a/app/views/rentals/_form_rental.html.erb
+++ b/app/views/rentals/_form_rental.html.erb
@@ -1,10 +1,8 @@
-<div class="container">
-  <%= simple_form_for [@housing, @rental] do |f| %>
-    <%= f.input :furnished %>
-    <%= f.input :start_date, as: :string, required: false, input_html: {class: "datepicker"} %>
-    <%= f.input :end_date, as: :string, required: false, input_html: {class: "datepicker"} %>
-    <%= f.input :monthly_rent %>
-    <%= f.input :monthly_expenses %>
-    <%= f.submit "Valider", class: "btn btn-primary" %>
-  <% end %>
-</div>
+<%= simple_form_for [@housing, @rental] do |f| %>
+  <%= f.input :furnished %>
+  <%= f.input :start_date, as: :string, required: false, input_html: {class: "datepicker"} %>
+  <%= f.input :end_date, as: :string, required: false, input_html: {class: "datepicker"} %>
+  <%= f.input :monthly_rent %>
+  <%= f.input :monthly_expenses %>
+  <%= f.submit "Valider", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,1 @@
-
- <footer class="footer">
-   i'm a sticky footer
- </footer>
+<span>Copyright © Hiry 2018.</span>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,30 +10,34 @@
     <% if user_signed_in? %>
 
       <!-- Links when logged in -->
-      <%= link_to "Host", "#", class: "navbar-wagon-item navbar-wagon-link" %>
-      <%= link_to "Trips", "#", class: "navbar-wagon-item navbar-wagon-link" %>
-      <%= link_to "Messages", "#", class: "navbar-wagon-item navbar-wagon-link" %>
+      <nav>
+        <%= link_to "Host", "#", class: "navbar-wagon-item navbar-wagon-link" %>
+        <%= link_to "Trips", "#", class: "navbar-wagon-item navbar-wagon-link" %>
+        <%= link_to "Messages", "#", class: "navbar-wagon-item navbar-wagon-link" %>
+      </nav>
 
       <!-- Avatar with dropdown menu -->
       <div class="navbar-wagon-item">
         <div class="dropdown">
           <%= image_tag "http://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbar-wagon-menu", "data-toggle" => "dropdown" %>
           <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
-            <li>
-              <%= link_to "#" do %>
-                <i class="fa fa-user"></i> <%= t(".profile", default: "Profile") %>
-              <% end %>
-            </li>
-            <li>
-              <%= link_to "#" do %>
-                <i class="fa fa-cog"></i>  <%= t(".settings", default: "Settings") %>
-              <% end %>
-            </li>
-            <li>
-              <%= link_to destroy_user_session_path, method: :delete do %>
-                <i class="fa fa-sign-out"></i>  <%= t(".sign_out", default: "Log out") %>
-              <% end %>
-            </li>
+            <nav>
+              <li>
+                <%= link_to "#" do %>
+                  <i class="fa fa-user"></i> <%= t(".profile", default: "Profile") %>
+                <% end %>
+              </li>
+              <li>
+                <%= link_to "#" do %>
+                  <i class="fa fa-cog"></i>  <%= t(".settings", default: "Settings") %>
+                <% end %>
+              </li>
+              <li>
+                <%= link_to destroy_user_session_path, method: :delete do %>
+                  <i class="fa fa-sign-out"></i>  <%= t(".sign_out", default: "Log out") %>
+                <% end %>
+              </li>
+            </nav>
           </ul>
         </div>
       </div>
@@ -48,11 +52,12 @@
     <div class="dropdown">
       <i class="fa fa-bars dropdown-toggle" data-toggle="dropdown"></i>
       <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
-        <li><a href="#">Some mobile link</a></li>
-        <li><a href="#">Other one</a></li>
-        <li><a href="#">Other one</a></li>
+        <nav>
+          <li><a href="#">Some mobile link</a></li>
+          <li><a href="#">Other one</a></li>
+          <li><a href="#">Other one</a></li>
+        </nav>
       </ul>
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
This PR makes the frontend less ugly by adding base CSS style to main components, including:

* navbar (now inside the grid)
* forms (now centered)
* footer (now sticky)
* webfont (using [Adobe Typekit](https://typekit.com/))

It also adds a few HTML 5 elements in the `application.html.erb` to make the markup more semantic.

Last but not least, this PR closes #24 and closes #15. 

![screenshot-2018-5-30 todo](https://user-images.githubusercontent.com/3286488/40716960-fab667c0-640a-11e8-9e18-6f08d773fdf1.png)
