### PR TITLE
Fix a bug where a wrong function name was causing Webpack to break

### DIFF
--- a/app/javascript/packs/map.js
+++ b/app/javascript/packs/map.js
@@ -1,6 +1,6 @@
 // app/javascript/packs/map.js
 import GMaps from 'gmaps/gmaps.js';
-import { autocomplete } from '../components/autocomplete';
+import { onPlaceChanged } from '../components/autocomplete';
 
 const mapElement = document.getElementById('map');
 if (mapElement) { // don't try to build a map if there's no div#map to inject in
@@ -17,4 +17,4 @@ if (mapElement) { // don't try to build a map if there's no div#map to inject in
   }
 }
 
-autocomplete();
+onPlaceChanged();


### PR DESCRIPTION
This PR renames `autocomplete` function into `onPlaceChanged` so that Webpack compiles again.