### PR TITLE
Hide footer on login and signup pages

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -1,3 +1,9 @@
+// Style for form-only page
+.form-page {
+  min-height: 100%;
+  margin-top: 10vh;
+}
+
 // Style for H3 title of forms
 .form-title {
   margin-bottom: ($spacer * 3) !important;

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,11 +1,13 @@
-<h3 class="form-title align-center">Mot de passe oublié ?</h3>
-<div class="row">
-  <div class="col-md-4 offset-md-4">
-    <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-      <%= f.error_notification %>
-      <%= f.input :email, label: 'E-mail', required: true, autofocus: true %>
-      <%= f.button :submit, 'Aidez-moi', class: "btn btn-primary btn-lg btn-block" %>
-    <% end %>
-    <%= render "devise/shared/links" %>
+<div class="form-page">
+  <h3 class="form-title align-center">Mot de passe oublié ?</h3>
+  <div class="row">
+    <div class="col-md-4 offset-md-4">
+      <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+        <%= f.error_notification %>
+        <%= f.input :email, label: 'E-mail', required: true, autofocus: true %>
+        <%= f.button :submit, 'Aidez-moi', class: "btn btn-primary btn-lg btn-block" %>
+      <% end %>
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,32 +1,34 @@
-<h3 class="form-title align-center">
-  Bienvenue sur Hiry.</br>
-  Nous sommes heureux de vous voir.
-</h3>
-<div class="row">
-  <div class="col-md-4 offset-md-4">
-    <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-      <%= f.error_notification %>
-      <%= f.input :email, {
-        label: 'E-mail',
-        placeholder: 'jean-michel.pignon@gmail.com',
-        required: true,
-        autofocus: true
-        }
-      %>
-      <%= f.input :password, {
-        required: true,
-        label: 'Mot de passe',
-        placeholder: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
-        }
-      %>
-      <%= f.input :password_confirmation, {
-        required: true,
-        label: 'Confirmation du mot de passe',
-        placeholder: 'Entrez-le de nouveau'
-        }
-      %>
-      <%= f.button :submit, 'Commencer', class: 'btn btn-primary btn-lg btn-block' %>
-    <% end %>
-    <%= render "devise/shared/links" %>
+<div class="form-page">
+  <h3 class="form-title align-center">
+    Bienvenue sur Hiry.</br>
+    Nous sommes heureux de vous voir.
+  </h3>
+  <div class="row">
+    <div class="col-md-4 offset-md-4">
+      <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= f.error_notification %>
+        <%= f.input :email, {
+          label: 'E-mail',
+          placeholder: 'jean-michel.pignon@gmail.com',
+          required: true,
+          autofocus: true
+          }
+        %>
+        <%= f.input :password, {
+          required: true,
+          label: 'Mot de passe',
+          placeholder: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
+          }
+        %>
+        <%= f.input :password_confirmation, {
+          required: true,
+          label: 'Confirmation du mot de passe',
+          placeholder: 'Entrez-le de nouveau'
+          }
+        %>
+        <%= f.button :submit, 'Commencer', class: 'btn btn-primary btn-lg btn-block' %>
+      <% end %>
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,12 +1,14 @@
-<h3 class="form-title align-center">Rebonjour</h3>
-<div class="row">
-  <div class="col-md-4 offset-md-4">
-    <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-      <%= f.input :email, required: false, autofocus: true %>
-      <%= f.input :password, required: false %>
-      <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
-      <%= f.button :submit, 'Log in', class: 'btn btn-primary btn-lg btn-block' %>
-    <% end %>
-    <%= render "devise/shared/links" %>
+<div class="form-page">
+  <h3 class="form-title align-center">Rebonjour</h3>
+  <div class="row">
+    <div class="col-md-4 offset-md-4">
+      <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+        <%= f.input :email, required: false, autofocus: true %>
+        <%= f.input :password, required: false %>
+        <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+        <%= f.button :submit, 'Log in', class: 'btn btn-primary btn-lg btn-block' %>
+      <% end %>
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,10 +28,10 @@
         <%= javascript_pack_tag 'application' %>
       </div>
     </main>
-    <footer class="footer">
-      <div class="container">
+    <footer>
+      <% if controller_name != 'sessions' && controller_name != 'registrations' && controller_name != 'passwords'%>
         <%= render 'shared/footer' %>
-      </div>
+      <% end %>
     </footer>
   </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,1 +1,5 @@
-<span>Copyright © Hiry 2018.</span>
+<div class="footer">
+  <div class="container">
+    <span>Copyright © Hiry 2018.</span>
+  </div>
+</div>


### PR DESCRIPTION
This PR hides the footer on a few pages where it's not necessary:

* `/users/sign_in`
* `/users/sign_up`
* `/users/password/new`

See it in action below:

![screenshot-2018-6-1 hiry 1](https://user-images.githubusercontent.com/3286488/40851121-a8bbd6e0-65c6-11e8-8049-f63c90569560.png)
