### PR TITLE
Separate rented housing from vacant ones on housing#index

### DIFF
--- a/app/assets/stylesheets/components/_card_housing.scss
+++ b/app/assets/stylesheets/components/_card_housing.scss
@@ -3,10 +3,30 @@
   width: 100%;
 }
 
+.housing-nav {
+  a {
+    text-decoration: none;
+    color: $black;
+  }
+  a:hover {
+    text-decoration: underline;
+    color: $black;
+  }
+}
+
 // Top part of the card
+.card-link {
+  a {
+    background: transparent;
+  }
+}
+
 .card-housing {
   text-transform: none;
   text-decoration: none;
+  &:hover {
+    background-color: $light-gray;
+  }
   a {
     color: $dark !important;
   }
@@ -17,13 +37,12 @@
 
 // Main flex contaiener for location part
 .card-location {
-  height: 9rem;
-  margin: 2rem 1.5rem;
+  padding: 2rem 1.5rem;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: stretch;
-  align-content: stretch;
+  align-content: space-between;
 }
 
 // Sub flex container for the text
@@ -32,16 +51,12 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  align-items: flex-start;
 }
 
 .card-location-title {
   font-weight: $font-weight-light;
   line-height: $line-height-lg;
-}
-
-// Flex item for text
-.card-date {
-  align-self: flex-start;
 }
 
 .card-date-title {

--- a/app/assets/stylesheets/pages/_housing.scss
+++ b/app/assets/stylesheets/pages/_housing.scss
@@ -1,13 +1,17 @@
 .page-content {
-  margin: 9rem 0;
+  margin: 5rem 0;
 }
 
-div.list-housing {
-  div.item-housing:first-child {
-    margin-top: 0;
-    margin-bottom: 2rem;
+div.vacant-housings-list,
+div.rented-housings-list {
+  .item-housing {
+    margin-bottom: 3rem;
   }
-  div.item-housing {
-    margin-bottom: 2rem;
+  .item-housing:last-child {
+    margin-bottom: 5rem;
   }
+}
+
+.housings-list-title {
+  margin-bottom: 2rem;
 }

--- a/app/controllers/housings_controller.rb
+++ b/app/controllers/housings_controller.rb
@@ -2,7 +2,8 @@ class HousingsController < ApplicationController
   before_action :set_housing, only: [:show]
 
   def index
-    @housings = policy_scope(Housing)
+    @rented_housings = policy_scope(Housing).joins(:rentals)
+    @vacant_housings = Housing.where.not(id: @rented_housings.pluck(:id))
     @housings = current_user.housings
 
     # Geocoding
@@ -15,7 +16,6 @@ class HousingsController < ApplicationController
       }
     end
   end
-
 
   def show
     authorize @housing

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,7 +9,6 @@ flatpickr(".datepicker", {
 
 hideFloorFieldIfHousingTypeIsHouse();
 
-
 if (document.getElementById("index_page")) {
  document.addEventListener("DOMContentLoaded", () => {
   const mini_maps = document.querySelectorAll(".mini_map");

--- a/app/javascript/packs/map.js
+++ b/app/javascript/packs/map.js
@@ -2,14 +2,16 @@
 import GMaps from 'gmaps/gmaps.js';
 import { onPlaceChanged } from '../components/autocomplete';
 
-
-
-
 function update_map (map_id) {
   const mapElement = document.getElementById(map_id);
-  console.log(mapElement);
-  if (mapElement) { // don't try to build a map if there's no div#map to inject in
-    const map = new GMaps({ el: `#${map_id}`, lat: 0, lng: 0 });
+  if (mapElement) { // Don't try to build a map if there's no div#map to inject in
+    const map = new GMaps({
+      el: `#${map_id}`,
+      lat: 0,
+      lng: 0,
+      disableDefaultUI: true, // Removes Google Map default UI
+      draggable: false, // Prevents the map from being dragged
+    });
     const markers = JSON.parse(mapElement.dataset.markers);
     map.addMarkers(markers);
     if (markers.length === 0) {
@@ -24,7 +26,5 @@ function update_map (map_id) {
 }
 
 update_map("map");
-
-//onPlaceChanged();
 
 export { update_map };

--- a/app/models/housing.rb
+++ b/app/models/housing.rb
@@ -2,7 +2,6 @@ class Housing < ApplicationRecord
   TYPE_OF_HOUSING = ["Appartement", "Maison"]
   LEGAL_REGIME_TYPE = ["Mono propriété", "Copropriété"]
 
-
   geocoded_by :address
   after_validation :geocode, if: :will_save_change_to_address?
   belongs_to :user

--- a/app/views/housings/_list_housings.html.erb
+++ b/app/views/housings/_list_housings.html.erb
@@ -1,31 +1,33 @@
 <div class="item-housing">
-    <div class="card-housing">
-      <%= link_to housing_path(housing), class: 'card-link' do %>
-        <div class="card-location">
-          <div class="card-location-text">
-            <h3 class="card-location-title">
-              <%= housing.street %><br><%= housing.zip_code %> <%= housing.city.upcase %>
-            </h3>
-            <div class="card-date">
-              <% if rental.present? && renter.present? %>
-                <h6 class="card-date-title">Loué depuis le <%= rental.start_date %> à <%= renter.first_name %> <%= renter.last_name %></h6>
-              <% else %>
-                <h6 class="card-date-title">Créé en <%= housing.created_at.strftime("%B, %Y") %></h6>
-              <% end %>
-            </div>
-          </div>
-          <!-- Adds a map to the housing car -->
-          <div class="card-location-map">
-            <% markers = [{ lat: housing.latitude, lng: housing.longitude }] %>
-            <div id=<%= "map#{housing.id}" %> class="mini_map" style="width: 100%; height: 100%;" data-markers="<%= markers.to_json %>"></div>
+
+  <!-- Top part of the housing card -->
+  <div class="card-housing">
+    <%= link_to housing_path(housing), class: 'card-link' do %>
+      <div class="card-location">
+        <div class="card-location-text">
+          <h3 class="card-location-title">
+            <%= housing.street %><br><%= housing.zip_code %> <%= housing.city.upcase %>
+          </h3>
+          <div class="card-date">
+            <% if defined?(rental) && renter.present? %>
+              <h6 class="card-date-title">Loué depuis le <%= rental.start_date %> à <%= renter.first_name %> <%= renter.last_name %></h6>
+            <% else %>
+              <h6 class="card-date-title">Créé en <%= housing.created_at.strftime("%B, %Y") %></h6>
+            <% end %>
           </div>
         </div>
-      <% end %>
-    </div>
+        <!-- Adds a map to the housing car -->
+        <div class="card-location-map">
+          <% markers = [{ lat: housing.latitude, lng: housing.longitude }] %>
+          <div id=<%= "map#{housing.id}" %> class="mini_map" style="width: 100%; height: 100%;" data-markers="<%= markers.to_json %>"></div>
+        </div>
+      </div>
+    <% end %>
+  </div>
 
   <!-- Adds a call to action to rent the housing if housing is empty -->
   <div class="card-rental-link">
-    <% if !rental.present? %>
+    <% unless defined?(rental) %>
       <%= link_to new_housing_rental_path(housing) do %>
         <div class="card-rental">
           <div class="card-rental-icon">

--- a/app/views/housings/index.html.erb
+++ b/app/views/housings/index.html.erb
@@ -10,23 +10,32 @@
 
 			<!-- Sticky sidebar navigation -->
 			<div class="col-md-3">
-				<nav class="nav flex-column">
-				  <a class="nav-link" href="#"><h2>À louer</h2></a>
-				  <a class="nav-link" href="#"><h2>En location</a>
+				<nav class="nav flex-column housing-nav">
+				  <a class="nav-link" href="#vacant-housing"><h4>À louer</h4></a>
+				  <a class="nav-link" href="#rented-housing"><h4>En location</h4></a>
 				</nav>
 			</div>
 
 			<!-- Housings lists -->
 	    <div class="col-md-9">
+
 	      <div class="list-housing">
-					<% @housings.each do |housing| %>
-						<% rental = Rental.where(housing_id: housing.id).last %>
-						<% if rental.present? %>
-							<% renter = Renter.where(rental_id: rental.id).last %>
+					<div class="vacant-housings-list">
+						<h2 id="vacant-housing" class="housings-list-title">À louer</h2>
+						<% @vacant_housings.each do |housing| %>
+							<%= render 'list_housings', housing: housing %>
 						<% end %>
-						<%= render 'list_housings', housing: housing, renter: renter, rental: rental %>
-					<% end %>
+					</div>
+					<div class="rented-housings-list">
+	          <h2 id="rented-housing" class="housings-list-title">En location</h2>
+						<% @rented_housings.each do |housing| %>
+							<% rental = Rental.where(housing_id: housing.id).last %>
+							<% renter = Renter.where(rental_id: rental.id).last %>
+							<%= render 'list_housings', housing: housing, renter: renter, rental: rental %>
+						<% end %>
+					<div class="rented-housing">
 				</div>
+
 				<!-- Adds button to the bottom of the housing list -->
 	      <%= link_to "Ajouter un bien", new_housing_path, class: "btn btn-primary btn-lg" %>
 	    </div>

--- a/app/views/housings/index.html.erb
+++ b/app/views/housings/index.html.erb
@@ -1,9 +1,11 @@
+<!-- Background image -->
 <div class="fullscreen fullscreen-img" style="background-image: linear-gradient(-225deg, rgba(0,0,0,0.2) 0%, rgba(44,44,44,0.2) 50%), url('https://res.cloudinary.com/bboulesteix/image/upload/v1528029627/housings-background_shrink.jpg')">
 	<div class="fullscreen-content">
 		<h1 class="fullscreen-title">Ma liste<br>de biens</h1>
 	</div>
 </div>
 
+<!-- Page container -->
 <div class="page-content">
 	<div class="container">
 	  <div id="index_page" class="row">
@@ -16,16 +18,18 @@
 				</nav>
 			</div>
 
-			<!-- Housings lists -->
+			<!-- Begin Housings lists -->
 	    <div class="col-md-9">
 
 	      <div class="list-housing">
+					<!-- Lists vacant housings first -->
 					<div class="vacant-housings-list">
 						<h2 id="vacant-housing" class="housings-list-title">À louer</h2>
 						<% @vacant_housings.each do |housing| %>
 							<%= render 'list_housings', housing: housing %>
 						<% end %>
 					</div>
+					<!-- Lists rented housings then -->
 					<div class="rented-housings-list">
 	          <h2 id="rented-housing" class="housings-list-title">En location</h2>
 						<% @rented_housings.each do |housing| %>
@@ -33,12 +37,11 @@
 							<% renter = Renter.where(rental_id: rental.id).last %>
 							<%= render 'list_housings', housing: housing, renter: renter, rental: rental %>
 						<% end %>
-					<div class="rented-housing">
+					</div>
 				</div>
 
-				<!-- Adds button to the bottom of the housing list -->
-	      <%= link_to "Ajouter un bien", new_housing_path, class: "btn btn-primary btn-lg" %>
 	    </div>
+			<!-- End housings list -->
 
 	  </div>
 	</div>


### PR DESCRIPTION
This PR introduces a split between `vacant housings` and `rented housings`
 on the `housing#index` page. It also changes the behaviour of maps.

1. Vacants housing are showed first, as a list, then rented housings are showed below, as a list too. This closes #82. 
2. Also, this PR disable Google Maps default UI on maps vignette. So this closes #87.

<img width="880" alt="capture d ecran 2018-06-04 11 50 19" src="https://user-images.githubusercontent.com/3286488/40910847-7e40a28c-67ed-11e8-861c-63e18c9c3a75.png">
