### PR TITLE
Adds Carrierwave gem to project

### DIFF
--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -41,6 +41,6 @@ class RentalsController < ApplicationController
   end
 
   def rental_params
-    params.require(:rental).permit(:furnished, :start_date, :end_date, :monthly_rent, :monthly_expenses)
+    params.require(:rental).permit(:furnished, :start_date, :end_date, :monthly_rent, :monthly_expenses, :file)
   end
 end

--- a/app/models/rental.rb
+++ b/app/models/rental.rb
@@ -10,4 +10,6 @@ class Rental < ApplicationRecord
   validates :monthly_expenses, presence: true, numericality: { only_integer: true, greater_than: 1,  less_than: 10_000 }
 
   accepts_nested_attributes_for :inventories
+  # Carrierwave gem
+  mount_uploader :file, FileUploader
 end

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -1,0 +1,6 @@
+class FileUploader < CarrierWave::Uploader::Base
+  include Cloudinary::CarrierWave
+
+  process eager: true  # Force version generation at upload time.
+  process convert: 'pdf'
+end

--- a/db/migrate/20180604125633_add_file_to_rentals.rb
+++ b/db/migrate/20180604125633_add_file_to_rentals.rb
@@ -1,0 +1,5 @@
+class AddFileToRentals < ActiveRecord::Migration[5.2]
+  def change
+    add_column :rentals, :file, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_31_151748) do
+ActiveRecord::Schema.define(version: 2018_06_04_125633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 2018_05_31_151748) do
     t.string "inventory_pdf"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "file"
     t.index ["housing_id"], name: "index_rentals_on_housing_id"
   end
 


### PR DESCRIPTION
This PR adds the Carrierwave gem to Hiry. Carrierwave works with Cloudinary to allow user to upload PDF if needed. This PR closes #103.

⚠️ Don't forget to run `bundle install` and `rails db:migrate` after your `git pull origin master`.