### PR TITLE
Fix Render for rentals and controllers

### DIFF
--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -10,11 +10,12 @@ class RentalsController < ApplicationController
   def create
     @rental = Rental.new(rental_params)
     @rental.housing = Housing.find(params[:housing_id])
+    @housing = @rental.housing
     @rental.renter_token = SecureRandom.hex(10)
     authorize @rental
 
-    if @rental.save!
-      redirect_to new_rental_renter_path(@rental), notice: 'Location Crée. Veuillez maintenant renseigner les informations sur le locataire.'
+    if @rental.save
+      redirect_to new_rental_renter_path(@rental), notice: 'Location Créée. Veuillez maintenant renseigner les informations sur le locataire.'
     else
       render :new
     end

--- a/app/controllers/renters_controller.rb
+++ b/app/controllers/renters_controller.rb
@@ -12,9 +12,8 @@ class RentersController < ApplicationController
     @renter.rental = @rental
     authorize @renter
 
-    if @renter.save!
+    if @renter.save
       GenerateLeasePdfService.new(@rental).call
-
       redirect_to rental_path(@renter.rental), notice: 'Le locataire a bien été ajouté.'
     else
       render :new

--- a/app/models/housing.rb
+++ b/app/models/housing.rb
@@ -15,8 +15,8 @@ class Housing < ApplicationRecord
 
   validates :type_of_housing,      presence: true, inclusion: { in: TYPE_OF_HOUSING }
   validates :legal_regime,         presence: true, inclusion: { in: LEGAL_REGIME_TYPE }
-  validates :floor,                presence: true, numericality: { only_integer: true, greater_than: 0 }, if: :appartement? # Name of private method
-  validates :year_of_construction, presence: true, numericality: { greater_than: 1000,  less_than: 2018 }
+  validates :floor,                presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: :appartement? # Name of private method
+  validates :year_of_construction, presence: true, numericality: { less_than: 2018 }
   validates :size,                 presence: true, numericality: { greater_than: 1,  less_than: 10_000 }
   validates :city,                 presence: true
 

--- a/app/views/housings/show.html.erb
+++ b/app/views/housings/show.html.erb
@@ -80,13 +80,13 @@
                 <% end %>
               <!-- if there is no rentals -->
               <% else %>
-                <div class="rental-info-card">
-                  <div class="rental-info-card-icon">
-                    <%= link_to new_housing_rental_path(@housing) do %>
+                <%= link_to new_housing_rental_path(@housing) do %>
+                  <div class="rental-info-card">
+                    <div class="rental-info-card-icon">
                       <i class="fas fa-plus plus-button"></i>
-                    <% end %>
+                    </div>
                   </div>
-                </div>
+                <% end %>
               <% end %>
             </div>
           </div>


### PR DESCRIPTION
- Avoid 500 if object cannot be saved (rentals and renters)
- Floor is_greater_or_equal to 0 (instead of greater than)
- Remove minimum year of validation on the date of construction
- Fix a button on the housing # show